### PR TITLE
Duplicated ingredients are not allowed

### DIFF
--- a/src/main/java/com/ydarias/recipes/myrecipes/controllers/IngredientsController.java
+++ b/src/main/java/com/ydarias/recipes/myrecipes/controllers/IngredientsController.java
@@ -2,9 +2,13 @@ package com.ydarias.recipes.myrecipes.controllers;
 
 import java.util.List;
 
+import com.ydarias.recipes.myrecipes.ingredients.AlreadyExistingIngredientException;
 import com.ydarias.recipes.myrecipes.ingredients.Ingredient;
 import com.ydarias.recipes.myrecipes.ingredients.IngredientCreationCommand;
 import com.ydarias.recipes.myrecipes.ingredients.IngredientsCatalog;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,8 +38,12 @@ public class IngredientsController {
         return IngredientsController.asIngredientResponse(createdIngredient);
     }
 
+    @ExceptionHandler(AlreadyExistingIngredientException.class)
+    public ResponseEntity<String> handleIngredientAlreadyExists(AlreadyExistingIngredientException e) {
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.CONFLICT);
+    }
+
     private static IngredientResponse asIngredientResponse(Ingredient ingredient) {
         return new IngredientResponse(ingredient.id(), ingredient.name(), ingredient.seasonality());
     }
-
 }

--- a/src/main/java/com/ydarias/recipes/myrecipes/ingredients/AlreadyExistingIngredientException.java
+++ b/src/main/java/com/ydarias/recipes/myrecipes/ingredients/AlreadyExistingIngredientException.java
@@ -1,0 +1,4 @@
+package com.ydarias.recipes.myrecipes.ingredients;
+
+public class AlreadyExistingIngredientException extends RuntimeException {
+}

--- a/src/main/java/com/ydarias/recipes/myrecipes/ingredients/AlreadyExistingIngredientException.java
+++ b/src/main/java/com/ydarias/recipes/myrecipes/ingredients/AlreadyExistingIngredientException.java
@@ -1,4 +1,7 @@
 package com.ydarias.recipes.myrecipes.ingredients;
 
 public class AlreadyExistingIngredientException extends RuntimeException {
+    public AlreadyExistingIngredientException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/com/ydarias/recipes/myrecipes/ingredients/ForPersistingIngredients.java
+++ b/src/main/java/com/ydarias/recipes/myrecipes/ingredients/ForPersistingIngredients.java
@@ -5,4 +5,5 @@ import java.util.List;
 public interface ForPersistingIngredients {
     List<Ingredient> getIngredients(int page, int size);
     Ingredient addIngredient(IngredientCreationCommand newIngredient);
+    boolean doesExist(String ingredientName);
 }

--- a/src/main/java/com/ydarias/recipes/myrecipes/ingredients/IngredientsCatalog.java
+++ b/src/main/java/com/ydarias/recipes/myrecipes/ingredients/IngredientsCatalog.java
@@ -17,6 +17,10 @@ public class IngredientsCatalog {
     }
 
     public Ingredient addIngredient(IngredientCreationCommand newIngredient) {
+        if (ingredientsRepository.doesExist(newIngredient.name())) {
+            throw new AlreadyExistingIngredientException();
+        }
+
         return ingredientsRepository.addIngredient(newIngredient);
     }
 }

--- a/src/main/java/com/ydarias/recipes/myrecipes/ingredients/IngredientsCatalog.java
+++ b/src/main/java/com/ydarias/recipes/myrecipes/ingredients/IngredientsCatalog.java
@@ -1,5 +1,6 @@
 package com.ydarias.recipes.myrecipes.ingredients;
 
+import java.text.MessageFormat;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -18,7 +19,8 @@ public class IngredientsCatalog {
 
     public Ingredient addIngredient(IngredientCreationCommand newIngredient) {
         if (ingredientsRepository.doesExist(newIngredient.name())) {
-            throw new AlreadyExistingIngredientException();
+            var errorMessage = MessageFormat.format("Ingredient {0} already exists", newIngredient.name());
+            throw new AlreadyExistingIngredientException(errorMessage);
         }
 
         return ingredientsRepository.addIngredient(newIngredient);

--- a/src/main/java/com/ydarias/recipes/myrecipes/repositories/InMemoryIngredientsRepository.java
+++ b/src/main/java/com/ydarias/recipes/myrecipes/repositories/InMemoryIngredientsRepository.java
@@ -38,4 +38,9 @@ public class InMemoryIngredientsRepository implements ForPersistingIngredients {
 
         return ingredient;
     }
+
+    @Override
+    public boolean doesExist(String ingredientName) {
+        return false;
+    }
 }

--- a/src/main/java/com/ydarias/recipes/myrecipes/repositories/InMemoryIngredientsRepository.java
+++ b/src/main/java/com/ydarias/recipes/myrecipes/repositories/InMemoryIngredientsRepository.java
@@ -41,6 +41,7 @@ public class InMemoryIngredientsRepository implements ForPersistingIngredients {
 
     @Override
     public boolean doesExist(String ingredientName) {
-        return false;
+        var matchingIngredients = internalIngredientsDictionary.stream().filter(ingredient -> ingredient.name().equals(ingredientName)).toList();
+        return matchingIngredients.size() > 0;
     }
 }

--- a/src/test/java/com/ydarias/recipes/myrecipes/ingredients/IngredientsCatalogTests.java
+++ b/src/test/java/com/ydarias/recipes/myrecipes/ingredients/IngredientsCatalogTests.java
@@ -1,6 +1,7 @@
 package com.ydarias.recipes.myrecipes.ingredients;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -48,5 +49,15 @@ public class IngredientsCatalogTests {
         var result = catalog.addIngredient(newPear);
 
         assertThat(result).isEqualTo(createdPear);
+    }
+
+
+    @Test
+    void errorIsThrownIfIngredientAlreadyExistsByName() {
+        var newPear = new IngredientCreationCommand("Pear", List.of("JUL", "AUG", "SEP", "OCT", "NOV"));
+
+        when(ingredientsRepository.doesExist("Pear")).thenReturn(true);
+
+        assertThrows(AlreadyExistingIngredientException.class, () -> catalog.addIngredient(newPear));
     }
 }


### PR DESCRIPTION
This PR closes #7 

<img width="1194" alt="My Sketches 3 - 2024-09-23 11 19 50 357" src="https://github.com/user-attachments/assets/0fe5570c-15fe-45c5-85ec-8a26c7282ed4">

The `IngredientsCatalog` checks the existence of the ingredient using the repository and if it already exists an exception is thrown. This handles the problem at domain level, but the Spring Boot controller also adds code to transform that exception into error 409.